### PR TITLE
fix: prevent MixinTargetAlreadyLoadedException on startup

### DIFF
--- a/src/main/java/net/libz/AutoConfigHelper.java
+++ b/src/main/java/net/libz/AutoConfigHelper.java
@@ -1,0 +1,24 @@
+package net.libz;
+
+import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.ConfigHolder;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+public class AutoConfigHelper {
+    private static Field holdersField;
+
+    @SuppressWarnings("unchecked")
+    public static Map<Class<?>, ConfigHolder<?>> getHolders() {
+        try {
+            if (holdersField == null) {
+                holdersField = AutoConfig.class.getDeclaredField("holders");
+                holdersField.setAccessible(true);
+            }
+            return (Map<Class<?>, ConfigHolder<?>>) holdersField.get(null);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to access AutoConfig.holders", e);
+        }
+    }
+}

--- a/src/main/java/net/libz/init/EventInit.java
+++ b/src/main/java/net/libz/init/EventInit.java
@@ -5,8 +5,8 @@ import me.shedaniel.autoconfig.serializer.ConfigSerializer;
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.libz.AutoConfigHelper;
 import net.libz.api.ConfigSync;
-import net.libz.mixin.config.AutoConfigAccess;
 import net.libz.network.LibzServerPacket;
 
 public class EventInit {
@@ -16,7 +16,7 @@ public class EventInit {
             // check local
             if (ConfigInit.CONFIG.syncConfig) {
                 if (server.isDedicated()) {
-                    AutoConfigAccess.getHolders().forEach((data, holder) -> {
+                    AutoConfigHelper.getHolders().forEach((data, holder) -> {
                         if (holder.getConfig() instanceof ConfigSync) {
                             ConfigSerializer<?> configSerializer = ((ConfigManager<?>) holder).getSerializer();
 
@@ -26,7 +26,7 @@ public class EventInit {
                         }
                     });
                 } else {
-                    AutoConfigAccess.getHolders().forEach((data, holder) -> {
+                    AutoConfigHelper.getHolders().forEach((data, holder) -> {
                         if (holder.getConfig() instanceof ConfigSync) {
                             holder.load();
                             ((ConfigSync) holder.getConfig()).updateConfig(holder.getConfig());

--- a/src/main/java/net/libz/network/LibzClientPacket.java
+++ b/src/main/java/net/libz/network/LibzClientPacket.java
@@ -13,9 +13,9 @@ import me.shedaniel.autoconfig.ConfigManager;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.libz.AutoConfigHelper;
 import net.libz.access.MouseAccessor;
 import net.libz.api.ConfigSync;
-import net.libz.mixin.config.AutoConfigAccess;
 import net.libz.network.packet.ConfigPacket;
 import net.libz.network.packet.MousePacket;
 import net.libz.util.ConfigHelper;
@@ -43,7 +43,7 @@ public class LibzClientPacket {
 
                     Jankson jankson = Jankson.builder().build();
 
-                    for (ConfigHolder<?> holder : AutoConfigAccess.getHolders().values()) {
+                    for (ConfigHolder<?> holder : AutoConfigHelper.getHolders().values()) {
                         if (((ConfigManager<?>) holder).getDefinition().name().equals(configName)) {
                             try {
                                 String mergedJson = oldJsonNode.toJson();

--- a/src/main/resources/libz.mixins.json
+++ b/src/main/resources/libz.mixins.json
@@ -3,11 +3,7 @@
   "minVersion": "0.8",
   "package": "net.libz.mixin",
   "compatibilityLevel": "JAVA_21",
-  "plugin": "net.libz.mixin.LibzMixinPlugin",
-  "mixins": [
-    "config.AutoConfigAccess",
-    "config.MarshallerImplMixin"
-  ],
+  "mixins": [],
   "client": [
     "client.InventoryScreenMixin",
     "client.HandledScreenMixin",


### PR DESCRIPTION
## Fix: crash on startup with certain mod combinations

Fixes issue #2.

### What was happening

LibZ has two mixins targeting classes inside cloth-config (`AutoConfig` and `MarshallerImpl`). Several mods load these classes during their `preLaunch` entrypoint. By the time LibZ's mixin subsystem tries to prepare those mixins, the targets are already in memory and can't be transformed anymore, resulting in a hard `MixinTargetAlreadyLoadedException` crash.

### What did I change

**`AutoConfigAccess`** - replaced with a plain reflection helper. The mixin only ever read the private `holders` field from `AutoConfig`, which reflection handles identically since it's only called at runtime.

**`MarshallerImplMixin`** - removed. It was adding `// client only` comments to JSON config files, which is cosmetic. The actual client-only sync logic in `EventInit` and `LibzClientPacket` is unaffected. Worth noting that a proper replacement would be post-processing the JSON after serialization rather than hooking into `MarshallerImpl` directly - flagging in case you want to revisit.

**`LibzMixinPlugin`** - removed from the mixin config. All its methods were no-ops.

### Tested with
- levelz-2.1
- levelz-fixes-1.3.1
- lvlz_artifacts-1.21.1-1
- lvlz_better_nether-1.21.1-1
- lvlz_deeper_and_darker-2
- lvlz_farmers_delight-2
- lvlz_oh_the_biomes-2
- partyaddon-1.5
- jobsaddon-1.2.5

<details>
<summary>Full mod stack</summary>
<li>Hybrid Aquatic 1.5.5</li>
<li>accessories-fabric-1.1.-beta.53+1.21.1</li>
<li>animatica-.6.1+1.21</li>
<li>antique-atlas-3.1.2+1.21</li>
<li>appleskin-fabric-mc1.21-3.6</li>
<li>architectury-13.8-fabric</li>
<li>armour-sound-tweak-updated-1.2-1.21</li>
<li>artifacts-fabric-13.2.1</li>
<li>atmosfera-2.5.7+mc1.21.1</li>
<li>balm-fabric-1.21.1-21.56</li>
<li>bclib-21.13</li>
<li>beekeeperhut-fabric-3.3+mc1.21.1</li>
<li>better_lib-fabric-1.21.1-1.19</li>
<li>betterendcities-1.</li>
<li>bettermounthud-1.2.4</li>
<li>better-nether-21.11</li>
<li>biolith-fabric-3.1</li>
<li>BOMD-1.1.2-1.21.1</li>
<li>bountiful-fabric-8.-beta.2</li>
<li>cardinal-components-api-6.1.3</li>
<li>Champions-1.6-1.21.1</li>
<li>citresewn-1.2.2+1.21</li>
<li>cloth-config-15.14-fabric</li>
<li>continuity-3.+1.21</li>
<li>coolrain-1.4.-1.21.1</li>
<li>Corgilib-Fabric-1.21.1-5.9</li>
<li>cristellib-fabric-1.21.1-3.3</li>
<li>cwb-fabric-3.+mc1.21</li>
<li>Dangerous Fabric - 1.21.1 v1.4.3</li>
<li>Debugify-1.21.1+1.</li>
<li>deeperdarker-fabric-1.21-1.3.3-plus-b</li>
<li>DistantHorizons-3.3-b-1.21.1-fabric-neoforge</li>
<li>Dungeons And Villages DeeperAndDarker 1.21.1</li>
<li>dynamic-fps-3.11.4+minecraft-1.21.-fabric</li>
<li>dynamicsurroundings-fabric-1.21.1-.4.2</li>
<li>e4mc-fabric-6.1.</li>
<li>ecologics-fabric-1.21.1-2.3.3</li>
<li>enchants-and-expeditions-1.21.1-v2.3.7</li>
<li>endrem-fabric-1.21.X-6.2</li>
<li>enhancedblockentities-.1.2+1.21</li>
<li>entity_model_features_1.21-fabric-3.1.1</li>
<li>entity_texture_features_1.21-fabric-7.1</li>
<li>entityculling-fabric-1.1.1-mc1.21.1</li>
<li>EuphoriaPatcher-1.8.6-r5.7.1-fabric</li>
<li>Explorify v1.6.4 f15-88.mod</li>
<li>fabric-api-.116.11+1.21.1</li>
<li>fabric-language-kotlin-1.13.1+kotlin.2.3.2</li>
<li>fabricskyboxes-.7.4+mc1.21</li>
<li>fabrishot-1.14.1</li>
<li>FallingTree-1.21.1-1.21.1.11</li>
<li>FarmersDelight-1.21.1-3.3.2+refabricated</li>
<li>fastquit-3.+1.2.6</li>
<li>ferritecore-7.3-fabric</li>
<li>fleeinganimals-4.+1.21</li>
<li>ForgeConfigAPIPort-v21.1.6-1.21.1-Fabric</li>
<li>friendsandfoes-fabric-4.25+mc1.21.1</li>
<li>fsb-interop-1.4.+mc1.21-build.54</li>
<li>fzzy_config-.7.6+1.21</li>
<li>galosphere_trimming-1.21.1-1.-fabric</li>
<li>Galosphere-1.21.1-1.5.3-Fabrirc</li>
<li>geckolib-fabric-1.21.1-4.8.4</li>
<li>Geophilic v3.4.6.mod</li>
<li>global-datapack-1.6.1</li>
<li>gravestones-1.3.+1.21+A</li>
<li>homeostatic-1.21.1-fabric-2.11.4</li>
<li>homeostaticseasons-1.21.1-fabric-1.1.5</li>
<li>ImmediatelyFast-Fabric-1.6.1+1.21.1</li>
<li>immersivelanterns-fabric-1.6-1.21.1</li>
<li>ImmersiveThunder-1.21.1+1.2.2</li>
<li>incapacitated-fabric-1.21.1-2.1</li>
<li>indium-1.35+mc1.21</li>
<li>iris-fabric-1.8.8+mc1.21.1</li>
<li>JEB-1.11-1.21.1</li>
<li>jobsaddon-1.2.5</li>
<li>jrftl-1.21-fabric-1.8.</li>
<li>kambrik-fabric-8.-beta.2</li>
<li>keepinventorypenalty-fabric-1.21.1-3.</li>
<li>lambdynamiclights-4.8.8+1.21.1</li>
<li>language-reload-1.7.6+1.21.1</li>
<li>levelz-2.1</li>
<li>levelz-fixes-1.3.1</li>
<li>libz-1.1.</li>
<li>lithium-fabric-.15.3+mc1.21.1</li>
<li>lithostitched-1.6.8-fabric-21.1</li>
<li>loot_n_explore-1.21-1.21.1</li>
<li>lvlz_artifacts-1.21.1-1.</li>
<li>lvlz_better_nether-1.21.1-1.</li>
<li>lvlz_deeper_and_darker-2.</li>
<li>lvlz_farmers_delight-2.</li>
<li>lvlz_oh_the_biomes-2.</li>
<li>main-menu-credits-1.2.</li>
<li>make_bubbles_pop-.3.-fabric-mc1.19.4-1.21</li>
<li>mcqoy-.4.1+fabric-1.2</li>
<li>midnightlib-fabric-1.9.2+1.21.1</li>
<li>mixintrace-1.1.1+1.17</li>
<li>modelfix-1.21-1.6-fabric</li>
<li>modernfix-fabric-5.25.1+mc1.21.1</li>
<li>modmenu-11.4</li>
<li>moonlight-1.21-2.29.33-fabric</li>
<li>morechathistory-1.3.1</li>
<li>moreculling-fabric-1.21.1-1.7</li>
<li>mru-1.19+LTS+1.21.1+fabric</li>
<li>NoChatReports-FABRIC-1.21.1-v2.9.1</li>
<li>nvidium-.3.1</li>
<li>Oh-The-Biomes-Weve-Gone-Fabric-2.5.5</li>
<li>Oh-The-Trees-Youll-Grow-fabric-1.21.1-5.3.</li>
<li>optigui-2.3.-beta.9+1.21</li>
<li>owo-lib-.12.15.4+1.21</li>
<li>paginatedadvancements-2.5.1</li>
<li>partyaddon-1.5</li>
<li>Ping-Wheel-1.12.2-fabric-1.21.1</li>
<li>placeholder-api-2.4.2+1.21</li>
<li>pneumonocore-1.3.1+1.21+A</li>
<li>polytone-1.21-3.6.6-fabric</li>
<li>progression-reborn-1.21.1-v1.5.11</li>
<li>puzzle-fabric-2.3.+1.21.1</li>
<li>reeses-sodium-options-fabric-1.8.3+mc1.21.4</li>
<li>regions-unexplored-.6+beta4-fabric-21.1</li>
<li>repurposed_structures_farmers_delight_compat_v7</li>
<li>repurposed_structures_friends_and_foes_compat_v9</li>
<li>repurposed_structures-7.5.2+1.21.1-fabric</li>
<li>Repurposed_Structures-Better_Monuments_v7</li>
<li>repurposed-end-2.1-1.21</li>
<li>resourcefullib-fabric-1.21-3.12</li>
<li>riverredux-fabric-.4.1</li>
<li>rrls-5.1+mc1.21.1-fabric</li>
<li>satisfying_buttons-fabric-1.1.2-1.21.1</li>
<li>sleep_tight-1.21-1.4.1-fabric</li>
<li>smarterfarmers-1.21-2.2.4-fabric</li>
<li>SnowUnderTrees-2.7.4+1.21.1</li>
<li>sodium-extra-fabric-.6.+mc1.21.1</li>
<li>sodium-fabric-.6.13+mc1.21.1</li>
<li>sodiumoptionsapi-fabric-1.1-1.21.1</li>
<li>sound-physics-remastered-fabric-1.21.1-1.5.1</li>
<li>sounds-2.4.22+lts+1.21.1-fabric</li>
<li>spiceoflife_classic-fabric-2.12+1.21.1</li>
<li>Structory_26.1_v1.3.16</li>
<li>structure_pool_api-fabric-1.2.1+1.21.1</li>
<li>SubtleEffects-fabric-1.21.1-1.14.2</li>
<li>surveyor-1.1.2+1.21</li>
<li>t_and_t-neoforge-fabric-1.13.7+1.21.1</li>
<li>TerraBlender-fabric-1.21.1-4.1.8</li>
<li>Terralith_1.21.x_v2.5.8</li>
<li>Terralith_ReStoned_v1.3.1</li>
<li>trashslot-fabric-1.21.1-21.1.4</li>
<li>travelersbackpack-fabric-1.21.1-1.1.35</li>
<li>trmt-.4-1.21+1.21.1</li>
<li>txnilib-fabric-1.24-1.21.1</li>
<li>underground_village-fabric-1.21.1-1.5.7</li>
<li>underground-rivers-1.2-fabric-21.1</li>
<li>undergroundworlds-fabric-3.1-1.21.1</li>
<li>void-totem-3</li>
<li>walllanterns-3.</li>
<li>waystones-fabric-1.21.1-21.1.32</li>
<li>worldweaver-21.13</li>
<li>yet_another_config_lib_v3-3.8.2+1.21.1-fabric</li>
<li>yosbr-.1.2</li>
<li>YungsApi-1.21.1-Fabric-5.1.6</li>
<li>YungsBetterEndIsland-1.21.1-Fabric-3.1.2</li>
<li>YungsBetterOceanMonuments-1.21.1-Fabric-4.1.2</li>
<li>YungsBetterWitchHuts-1.21.1-Fabric-4.1.1</li>
<li>YungsBridges-1.21.1-Fabric-5.1.1</li>
<li>YungsExtras-1.21.1-Fabric-5.1.1</li>
<li>zoomify-2.15.2+1.21.1</li>
</details>